### PR TITLE
Replace Steam Audio backend with pyopenal

### DIFF
--- a/addon/globalPlugins/Unspoken/addonGui.py
+++ b/addon/globalPlugins/Unspoken/addonGui.py
@@ -149,7 +149,7 @@ class SettingsPanel(gui.settingsDialogs.SettingsPanel):
 		config.conf["unspoken"]["volumeAdjust"] = self.volumeCheckBox.IsChecked()
 
 	def update_reverb_from_config(self):
-		# Update Steam Audio reverb settings
+		# Update spatial audio reverb settings
 		try:
 			from . import steam_audio
 

--- a/addon/globalPlugins/Unspoken/steam_audio.py
+++ b/addon/globalPlugins/Unspoken/steam_audio.py
@@ -1,314 +1,340 @@
-"""
-Python ctypes binding for Steam Audio DLL
-Provides 3D audio positioning, reverb, and 16-bit sample output
+"""Spatial audio engine built on top of pyopenal.
+
+This module provides a drop-in replacement for the old Steam Audio DLL
+interface.  It exposes a small wrapper that manages an OpenAL device/context
+and offers helpers for playing mono PCM samples positioned in 3D space.
+
+The implementation intentionally keeps the public API compatible with the
+previous wrapper when possible so the rest of the add-on can keep importing the
+module using the same name.
 """
 
-import ctypes
-import os
-import struct
+import math
 import threading
-from ctypes import c_bool, c_int, c_float, POINTER, byref
+import time
+from array import array
+from ctypes import byref, c_char, c_int, c_uint
 
 try:
-	from logHandler import log
-except ImportError:
-	import logging as log
+        from logHandler import log
+except ImportError:  # pragma: no cover - NVDA-only dependency
+        import logging as log
 
-# Global mutex for thread-safe DLL access
-_steam_audio_mutex = threading.Lock()
+try:
+        from openal.al import (
+                AL_BUFFER,
+                AL_FORMAT_MONO16,
+                AL_GAIN,
+                AL_PLAYING,
+                AL_POSITION,
+                AL_ROLLOFF_FACTOR,
+                AL_SOURCE_STATE,
+                alBufferData,
+                alDeleteBuffers,
+                alDeleteSources,
+                alGenBuffers,
+                alGenSources,
+                alGetSourcei,
+                alSource3f,
+                alSourcePlay,
+                alSourceStop,
+                alSourcef,
+                alSourcei,
+        )
+        from openal.alc import (
+                alcCloseDevice,
+                alcCreateContext,
+                alcDestroyContext,
+                alcMakeContextCurrent,
+                alcOpenDevice,
+        )
+except ImportError as e:  # pragma: no cover - handled at runtime
+        raise ImportError(
+                "pyopenal is required to run the Unspoken add-on. Please install the"
+                " 'openal' package."
+        ) from e
 
 
-# Define ctypes for the DLL functions
+_openal_mutex = threading.RLock()
+
+
+def _clamp_sample(value):
+        return max(min(int(value), 32767), -32768)
+
+
 class SteamAudio:
-	def __init__(self, dll_path=None):
-		"""Initialize Steam Audio wrapper
+        """Python implementation of the audio engine using pyopenal."""
 
-		Args:
-		    dll_path: Path to steam_audio.dll. If None, looks in addon directory.
-		"""
-		self.dll = None
-		self.initialized = False
+        def __init__(self, output_device=None):
+                self.device = None
+                self.context = None
+                self.initialized = False
+                self.sample_rate = 44100
+                self.output_device = output_device
+                self._active_handles = []
+                self._reverb_settings = {
+                        "room_size": 0.1,
+                        "damping": 0.5,
+                        "wet_level": 0.1,
+                        "dry_level": 1.0,
+                        "width": 1.0,
+                }
 
-		if dll_path is None:
-			# Look for DLL in the same directory as this module
-			addon_dir = os.path.dirname(__file__)
-			dll_path = os.path.join(addon_dir, "steam_audio.dll")
+        # ------------------------------------------------------------------
+        # Initialization / shutdown
+        # ------------------------------------------------------------------
+        def initialize(self, sample_rate=44100, frame_size=1024, output_device=None):
+                """Initialise OpenAL using pyopenal."""
+                if output_device is not None:
+                        self.output_device = output_device
+                with _openal_mutex:
+                        if self.initialized:
+                                return True
+                        device_name = None
+                        if self.output_device:
+                                try:
+                                        device_name = self.output_device.encode("utf-8")
+                                except Exception:
+                                        device_name = None
+                        device = alcOpenDevice(device_name)
+                        if not device and device_name:
+                                log.warning(
+                                        "Failed to open OpenAL device %r, falling back to default",
+                                        self.output_device,
+                                )
+                                device = alcOpenDevice(None)
+                        if not device:
+                                log.error("Unable to open OpenAL device")
+                                return False
+                        context = alcCreateContext(device, None)
+                        if not context:
+                                log.error("Unable to create OpenAL context")
+                                alcCloseDevice(device)
+                                return False
+                        if not alcMakeContextCurrent(context):
+                                log.error("Unable to make OpenAL context current")
+                                alcDestroyContext(context)
+                                alcCloseDevice(device)
+                                return False
+                        self.device = device
+                        self.context = context
+                        self.initialized = True
+                        self.sample_rate = sample_rate
+                        self._active_handles = []
+                        log.debug("OpenAL initialised successfully")
+                        return True
 
-		if not os.path.exists(dll_path):
-			raise FileNotFoundError(f"Steam Audio DLL not found at: {dll_path}")
+        def reinitialize(self, output_device=None):
+                with _openal_mutex:
+                        self.cleanup()
+                        return self.initialize(output_device=output_device)
 
-		try:
-			self.dll = ctypes.CDLL(dll_path)
-			self._setup_function_signatures()
-			log.debug(f"Steam Audio DLL loaded from: {dll_path}")
-		except Exception as e:
-			log.error(f"Failed to load Steam Audio DLL: {e}")
-			raise
+        def cleanup(self):
+                with _openal_mutex:
+                        if not self.initialized:
+                                return
+                        for source_id, buffer_id in list(self._active_handles):
+                                try:
+                                        alSourceStop(source_id.value)
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteSources(1, byref(source_id))
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteBuffers(1, byref(buffer_id))
+                                except Exception:
+                                        pass
+                        self._active_handles.clear()
+                        alcMakeContextCurrent(None)
+                        if self.context:
+                                alcDestroyContext(self.context)
+                                self.context = None
+                        if self.device:
+                                alcCloseDevice(self.device)
+                                self.device = None
+                        self.initialized = False
+                        log.debug("OpenAL cleaned up")
 
-	def _setup_function_signatures(self):
-		"""Setup ctypes function signatures for all DLL functions"""
+        # ------------------------------------------------------------------
+        # Reverb helpers
+        # ------------------------------------------------------------------
+        def set_reverb_settings(self, room_size, damping, wet_level, dry_level, width):
+                """Store reverb configuration for later playback."""
+                with _openal_mutex:
+                        self._reverb_settings = {
+                                "room_size": max(0.0, min(room_size, 1.0)),
+                                "damping": max(0.0, min(damping, 1.0)),
+                                "wet_level": max(0.0, min(wet_level, 1.0)),
+                                "dry_level": max(0.0, min(dry_level, 1.0)),
+                                "width": max(0.0, min(width, 1.0)),
+                        }
+                        log.debug("Updated reverb settings: %s", self._reverb_settings)
+                return True
 
-		# bool initialize_steam_audio(int samplingrate, int framesize)
-		self.dll.initialize_steam_audio.argtypes = [c_int, c_int]
-		self.dll.initialize_steam_audio.restype = c_bool
+        def _apply_reverb(self, pcm_data, sample_rate):
+                                if not pcm_data:
+                                        return pcm_data
+                                settings = self._reverb_settings
+                                delay = max(
+                                        1,
+                                        int(
+                                                sample_rate
+                                                * (0.01 + settings["room_size"] * (0.05 + 0.02 * settings["width"]))
+                                        ),
+                                )
+                                damping = 0.2 + 0.6 * settings["damping"]
+                                wet_gain = settings["wet_level"]
+                                dry_gain = settings["dry_level"] if settings["dry_level"] > 0 else 1.0
+                                samples = array("h")
+                                samples.frombytes(pcm_data)
+                                output = array("h", samples)
+                                for i in range(len(output)):
+                                        dry_component = dry_gain * samples[i]
+                                        wet_component = 0.0
+                                        if i >= delay:
+                                                wet_component = wet_gain * output[i - delay] * damping
+                                        mixed = _clamp_sample(dry_component + wet_component)
+                                        output[i] = mixed
+                                return output.tobytes()
 
-		# void cleanup_steam_audio()
-		self.dll.cleanup_steam_audio.argtypes = []
-		self.dll.cleanup_steam_audio.restype = None
+        # ------------------------------------------------------------------
+        # Playback
+        # ------------------------------------------------------------------
+        def stop_all(self):
+                with _openal_mutex:
+                        if not self.initialized:
+                                self._active_handles.clear()
+                                return
+                        for source_id, buffer_id in list(self._active_handles):
+                                try:
+                                        alSourceStop(source_id.value)
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteSources(1, byref(source_id))
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteBuffers(1, byref(buffer_id))
+                                except Exception:
+                                        pass
+                        self._active_handles.clear()
 
-		# bool set_reverb_settings(float room_size, float damping, float wet_level, float dry_level, float width)
-		self.dll.set_reverb_settings.argtypes = [
-			c_float,
-			c_float,
-			c_float,
-			c_float,
-			c_float,
-		]
-		self.dll.set_reverb_settings.restype = c_bool
+        def _angles_to_position(self, angle_x, angle_y):
+                azimuth = math.radians(angle_x)
+                elevation = math.radians(angle_y)
+                x = math.cos(elevation) * math.sin(azimuth)
+                y = math.sin(elevation)
+                z = math.cos(elevation) * math.cos(azimuth)
+                return (x, y, z)
 
-		# bool process_sound(const float* input_buffer, int input_length, float angle_x, float angle_y, int16_t** output_buffer, int* output_length)
-		self.dll.process_sound.argtypes = [
-			POINTER(c_float),  # input_buffer
-			c_int,  # input_length
-			c_float,  # angle_x
-			c_float,  # angle_y
-			POINTER(POINTER(ctypes.c_int16)),  # output_buffer
-			POINTER(c_int),  # output_length
-		]
-		self.dll.process_sound.restype = c_bool
+        def play_sound(
+                self,
+                _cache_key,
+                pcm_data,
+                sample_rate,
+                angle_x,
+                angle_y,
+                volume=1.0,
+                enable_reverb=True,
+        ):
+                if not self.initialized:
+                        log.error("OpenAL not initialised")
+                        return False
+                if not pcm_data:
+                        return False
+                gain = max(0.0, min(volume, 2.0))
+                if enable_reverb:
+                        try:
+                                pcm_data = self._apply_reverb(pcm_data, sample_rate)
+                        except Exception as e:
+                                log.error("Failed to apply reverb: %s", e)
+                x, y, z = self._angles_to_position(angle_x, angle_y)
+                buffer_id = c_uint(0)
+                source_id = c_uint(0)
+                audio_buffer = (c_char * len(pcm_data)).from_buffer_copy(pcm_data)
+                with _openal_mutex:
+                        alGenBuffers(1, byref(buffer_id))
+                        alBufferData(buffer_id.value, AL_FORMAT_MONO16, audio_buffer, len(pcm_data), sample_rate)
+                        alGenSources(1, byref(source_id))
+                        alSourcei(source_id.value, AL_BUFFER, buffer_id.value)
+                        alSourcef(source_id.value, AL_GAIN, gain)
+                        alSource3f(source_id.value, AL_POSITION, x, y, z)
+                        try:
+                                alSourcef(source_id.value, AL_ROLLOFF_FACTOR, 1.0)
+                        except Exception:
+                                pass
+                        alSourcePlay(source_id.value)
+                        self._active_handles.append((source_id, buffer_id))
+                threading.Thread(
+                        target=self._monitor_source,
+                        args=(source_id, buffer_id),
+                        daemon=True,
+                ).start()
+                return True
 
-		# bool apply_reverb(const int16_t* input_buffer, int input_length, int16_t** output_buffer, int* output_length)
-		self.dll.apply_reverb.argtypes = [
-			POINTER(ctypes.c_int16),  # input_buffer
-			c_int,  # input_length
-			POINTER(POINTER(ctypes.c_int16)),  # output_buffer
-			POINTER(c_int),  # output_length
-		]
-		self.dll.apply_reverb.restype = c_bool
+        def _monitor_source(self, source_id, buffer_id):
+                state = c_int(AL_PLAYING)
+                try:
+                        while True:
+                                with _openal_mutex:
+                                        alGetSourcei(source_id.value, AL_SOURCE_STATE, byref(state))
+                                if state.value != AL_PLAYING:
+                                        break
+                                time.sleep(0.01)
+                finally:
+                        with _openal_mutex:
+                                try:
+                                        alSourceStop(source_id.value)
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteSources(1, byref(source_id))
+                                except Exception:
+                                        pass
+                                try:
+                                        alDeleteBuffers(1, byref(buffer_id))
+                                except Exception:
+                                        pass
+                                self._active_handles = [
+                                        handle
+                                        for handle in self._active_handles
+                                        if handle[0].value != source_id.value
+                                ]
 
-		# void free_output_sound(int16_t* buffer)
-		self.dll.free_output_sound.argtypes = [POINTER(ctypes.c_int16)]
-		self.dll.free_output_sound.restype = None
+        # Compatibility helpers ------------------------------------------------
+        def process_sound(self, input_buffer, angle_x, angle_y):  # pragma: no cover - legacy API
+                raise NotImplementedError("process_sound is no longer available; use play_sound().")
 
-	def initialize(self, sample_rate=44100, frame_size=1024):
-		"""Initialize Steam Audio with given parameters
+        def apply_reverb(self, input_buffer):  # pragma: no cover - legacy API
+                raise NotImplementedError("apply_reverb is no longer available; use play_sound().")
 
-		Args:
-		    sample_rate: Audio sample rate in Hz (default: 44100)
-		    frame_size: Audio frame size in samples (default: 1024)
-
-		Returns:
-		    bool: True if initialization successful, False otherwise
-		"""
-		if self.initialized:
-			log.debug("Steam Audio already initialized")
-			return True
-
-		with _steam_audio_mutex:
-			success = self.dll.initialize_steam_audio(sample_rate, frame_size)
-			if success:
-				self.initialized = True
-				self.sample_rate = sample_rate
-				self.frame_size = frame_size
-				log.debug(
-					f"Steam Audio initialized: {sample_rate}Hz, {frame_size} samples"
-				)
-			else:
-				log.error("Failed to initialize Steam Audio")
-
-		return success
-
-	def cleanup(self):
-		"""Cleanup Steam Audio resources"""
-		if self.initialized:
-			with _steam_audio_mutex:
-				self.dll.cleanup_steam_audio()
-				self.initialized = False
-			log.debug("Steam Audio cleaned up")
-
-	def set_reverb_settings(self, room_size, damping, wet_level, dry_level, width):
-		"""Configure verblib reverb settings
-
-		Args:
-		    room_size: Room size (0.0 to 1.0)
-		    damping: Damping amount (0.0 to 1.0,)
-		    wet_level: Wet signal level (0.0 to 1.0, default)
-		    dry_level: Dry signal level (0.0 to 1.0)
-		    width: Stereo width (0.0 to 1.0)
-
-		Returns:
-		    bool: True if successful
-		"""
-		if not self.initialized:
-			log.error("Steam Audio not initialized")
-			return False
-
-		with _steam_audio_mutex:
-			success = self.dll.set_reverb_settings(
-				room_size, damping, wet_level, dry_level, width
-			)
-			if success:
-				log.debug(
-					f"Reverb settings updated: room_size={room_size}, damping={damping}, wet_level={wet_level}, dry_level={dry_level}, width={width}"
-				)
-			else:
-				log.error("Failed to set reverb settings")
-
-		return success
-
-	def process_sound(self, input_buffer, angle_x, angle_y):
-		"""Process audio with 3D positioning (without reverb)
-
-		Args:
-		    input_buffer: list of float32 mono audio samples
-		    angle_x: Horizontal angle in degrees (-90 to 90)
-		    angle_y: Vertical angle in degrees (-90 to 90)
-
-		Returns:
-		    bytes: Stereo 16-bit audio samples as bytes, or None if failed
-		"""
-		if not self.initialized:
-			log.error("Steam Audio not initialized")
-			return None
-
-		# Convert list to ctypes array
-		input_array = (c_float * len(input_buffer))(*input_buffer)
-		input_ptr = ctypes.cast(input_array, POINTER(c_float))
-		input_length = len(input_buffer)
-
-		# Prepare output parameters
-		output_buffer_ptr = POINTER(ctypes.c_int16)()
-		output_length = c_int()
-
-		# Call the DLL function
-		with _steam_audio_mutex:
-			success = self.dll.process_sound(
-				input_ptr,
-				input_length,
-				c_float(angle_x),
-				c_float(angle_y),
-				byref(output_buffer_ptr),
-				byref(output_length),
-			)
-
-		if not success or not output_buffer_ptr:
-			log.error("Failed to process sound")
-			return None
-
-		try:
-			# Convert output to bytes
-			output_samples = output_length.value
-			if output_samples > 0:
-				# Pack int16 samples into bytes
-				result = struct.pack(
-					f"<{output_samples}h",
-					*[output_buffer_ptr[i] for i in range(output_samples)],
-				)
-
-				# Free the output buffer
-				with _steam_audio_mutex:
-					self.dll.free_output_sound(output_buffer_ptr)
-
-				return result
-			else:
-				return b""
-
-		except Exception as e:
-			log.error(f"Error processing output buffer: {e}")
-			# Make sure to free the buffer even if there's an error
-			if output_buffer_ptr:
-				with _steam_audio_mutex:
-					self.dll.free_output_sound(output_buffer_ptr)
-			return None
-
-	def apply_reverb(self, input_buffer):
-		"""Apply reverb to stereo 16-bit audio
-
-		Args:
-		    input_buffer: bytes of stereo 16-bit audio samples
-
-		Returns:
-		    bytes: Stereo 16-bit audio samples with reverb, or None if failed
-		"""
-		if not self.initialized:
-			log.error("Steam Audio not initialized")
-			return None
-
-		# Convert bytes to int16 array
-		import struct
-
-		samples = struct.unpack(f"<{len(input_buffer) // 2}h", input_buffer)
-		input_array = (ctypes.c_int16 * len(samples))(*samples)
-		input_ptr = ctypes.cast(input_array, POINTER(ctypes.c_int16))
-		input_length = len(samples)
-
-		# Prepare output parameters
-		output_buffer_ptr = POINTER(ctypes.c_int16)()
-		output_length = c_int()
-
-		# Call the DLL function
-		with _steam_audio_mutex:
-			success = self.dll.apply_reverb(
-				input_ptr, input_length, byref(output_buffer_ptr), byref(output_length)
-			)
-
-		if not success or not output_buffer_ptr:
-			log.error("Failed to apply reverb")
-			return None
-
-		try:
-			# Convert output to bytes
-			output_samples = output_length.value
-			if output_samples > 0:
-				# Pack int16 samples into bytes
-				result = struct.pack(
-					f"<{output_samples}h",
-					*[output_buffer_ptr[i] for i in range(output_samples)],
-				)
-
-				# Free the output buffer
-				with _steam_audio_mutex:
-					self.dll.free_output_sound(output_buffer_ptr)
-
-				return result
-			else:
-				return b""
-
-		except Exception as e:
-			log.error(f"Error processing reverb output buffer: {e}")
-			# Make sure to free the buffer even if there's an error
-			if output_buffer_ptr:
-				with _steam_audio_mutex:
-					self.dll.free_output_sound(output_buffer_ptr)
-			return None
-
-	def __del__(self):
-		"""Cleanup when object is destroyed"""
-		if hasattr(self, "initialized") and self.initialized:
-			self.cleanup()
+        def __del__(self):  # pragma: no cover - cleanup helper
+                try:
+                        self.cleanup()
+                except Exception:
+                        pass
 
 
-# Global instance for easy access
 _steam_audio_instance = None
 
 
 def get_steam_audio():
-	"""Get the global Steam Audio instance"""
-	global _steam_audio_instance
-	if _steam_audio_instance is None:
-		_steam_audio_instance = SteamAudio()
-	return _steam_audio_instance
+        global _steam_audio_instance
+        if _steam_audio_instance is None:
+                _steam_audio_instance = SteamAudio()
+        return _steam_audio_instance
 
 
-def initialize_steam_audio(sample_rate=44100, frame_size=1024):
-	"""Initialize the global Steam Audio instance"""
-	steam_audio = get_steam_audio()
-	return steam_audio.initialize(sample_rate, frame_size)
+def initialize_steam_audio(sample_rate=44100, frame_size=1024, output_device=None):
+        engine = get_steam_audio()
+        return engine.initialize(sample_rate=sample_rate, frame_size=frame_size, output_device=output_device)
 
 
 def cleanup_steam_audio():
-	"""Cleanup the global Steam Audio instance"""
-	global _steam_audio_instance
-	if _steam_audio_instance:
-		_steam_audio_instance.cleanup()
-		_steam_audio_instance = None
+        global _steam_audio_instance
+        if _steam_audio_instance:
+                _steam_audio_instance.cleanup()
+                _steam_audio_instance = None


### PR DESCRIPTION
## Summary
- replace the Steam Audio ctypes wrapper with a pyopenal-driven OpenAL engine that manages device/context lifetimes, playback, and lightweight reverb processing
- update the global plugin to preload mono PCM role sounds, drop the nvwave wave player, and route playback through the new spatial audio helper
- refresh the settings panel helper text so reverb adjustments refer to the spatial audio engine

## Testing
- python -m compileall addon/globalPlugins/Unspoken/__init__.py addon/globalPlugins/Unspoken/addonGui.py
- python -m compileall addon/globalPlugins/Unspoken/steam_audio.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179a8d7d208330aab67fe4ccb905c7)