### PR TITLE
fix: call idle() after feed() to release audio ducking

### DIFF
--- a/addon/globalPlugins/Unspoken/__init__.py
+++ b/addon/globalPlugins/Unspoken/__init__.py
@@ -388,6 +388,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             if generation != self._sound_generation:
                 return
             self.wave_player.feed(final_audio)
+            self.wave_player.idle()
 
     def event_gainFocus(self, obj, nextHandler):
         # Always call nextHandler first to avoid blocking navigation


### PR DESCRIPTION
## Summary

- Adds `wave_player.idle()` after `feed()` in `_play_sound_async` to properly release NVDA's audio ducker
- `feed()` enables ducking but `idle()` was never called, causing permanent volume reduction of other apps when "Duck when outputting speech and sounds" is enabled

## Test plan

- [ ] Set NVDA audio ducking to "Duck when outputting speech and sounds"
- [ ] Play background audio (music, video, etc.)
- [ ] Navigate UI elements to trigger Unspoken sounds
- [ ] Stop navigating and wait 2-3 seconds
- [ ] Confirm background audio volume returns to normal